### PR TITLE
Add gitea.trust_bundle parameter for specifying TLS CA bundle configmap

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -115,3 +115,32 @@ The places where you must update those sources are then, respectively:
 If you intend on using `hack/operate.sh` it expects you to be in a development environment. Operator installation from this script therefore expects access to the internet. This comes with one extra concern: If `kustomize` isn't in your path, it tries to download it from the internet and save it locally into a `.gitignore`d folder. If you intend on using `hack/operate.sh` to install the operator, you should also bring `kustomize` and place it in the `$PATH` of the user who will be running the script. Additionally, in order to install the operator with `hack/operate.sh` you'll need to make the following change:
 
 . `hack/operate.conf`: IMG should point to the gitea-operator image in your environment
+
+== Adding an additional Certificate Authority trust bundle
+
+The operator can mount an additional trust bundle `ConfigMap` into the Gitea pod. Create your `ConfigMap` and set the `spec.gitea.trustBundleConfigMap` parameter to the name of the `ConfigMap`. The `ConfigMap` must be in the
+same namespace as the `Gitea` custom resource.
+
+The CA bundle must be included under a key named `ca-bundle.crt` within the `ConfigMap`. The resulting CA bundle will be mounted at `/etc/pki/tls/certs/ca-bundle.crt` in the Gitea pod.
+
+Example:
+
+```
+apiVersion: redhatgov.io/v1alpha1
+kind: Gitea
+metadata:
+  name: gitea-sample
+spec:
+  gitea:
+    expose:
+      kind: Ingress
+      ssl: true
+      uri: gitea-sample.example.com
+    image:
+      pullPolicy: Always
+      src: quay.io/redhatgov/gitea
+      tag: latest
+    trustBundleConfigMap: user-ca-bundle
+  postgresql:
+    volumeSize: 1Gi
+```

--- a/config/crd/bases/redhatgov.io_giteas.yaml
+++ b/config/crd/bases/redhatgov.io_giteas.yaml
@@ -47,6 +47,13 @@ spec:
                 description: Defines the desired state of the Gitea Deployment
                 type: object
                 properties:
+                  trustBundleConfigMap:
+                    description: |
+                      The name of a ConfigMap of CA certificates to mount into the Gitea pod. The ConfigMap
+                      should have a single key named ca-bundle.crt. This key has a collection of CA certificates
+                      as its value.
+                    type: string
+                    default: ''
                   expose:
                     description: Defines the ways in which Gitea should be exposed
                     type: object

--- a/playbooks/gitea-operator.yml
+++ b/playbooks/gitea-operator.yml
@@ -53,3 +53,5 @@
       _gitea_memory_limit: "{{ gitea.resources.memory.limit | default('512Mi') }}"
       _gitea_cpu_request: "{{ gitea.resources.cpu.request | default('200m') }}"
       _gitea_cpu_limit: "{{ gitea.resources.cpu.limit | default('500m') }}"
+
+      _gitea_trust_bundle_configmap: "{{ gitea.trust_bundle_config_map | default('') }}"

--- a/roles/gitea-ocp/defaults/main.yml
+++ b/roles/gitea-ocp/defaults/main.yml
@@ -29,3 +29,5 @@ _gitea_expose_method: Route
 _gitea_expose_uri: ""
 _gitea_route: "{{ _gitea_expose_uri }}"
 _gitea_ssl: true
+
+_gitea_trust_bundle_configmap: ''

--- a/roles/gitea-ocp/templates/deployment.yml.j2
+++ b/roles/gitea-ocp/templates/deployment.yml.j2
@@ -55,9 +55,18 @@ spec:
         - name: gitea-repositories
           mountPath: /gitea-repositories
 {% endif %}
+{% if _gitea_trust_bundle_configmap != '' %}
+        - name: gitea-trust-bundle
+          mountPath: /etc/pki/tls/certs
+{% endif %}
         - name: gitea-config
           mountPath: /home/gitea/conf
       volumes:
+{% if _gitea_trust_bundle_configmap != '' %}
+      - name: gitea-trust-bundle
+        configMap:
+          name: "{{ _gitea_trust_bundle_configmap }}"
+{% endif %}
 {% if _gitea_persistent|bool %}
       - name: gitea-repositories
         persistentVolumeClaim:


### PR DESCRIPTION
Currently, there is no way to add an additional trusted CA bundle into the Gitea pod. This PR adds an additional parameter for specifying the name of a ConfigMap that will be mounted under /etc/pki/tls/certs.