### PR TITLE
Disable user registration via UI 

### DIFF
--- a/roles/gitea-ocp/templates/config_map.yml.j2
+++ b/roles/gitea-ocp/templates/config_map.yml.j2
@@ -46,7 +46,7 @@ data:
     [service]
     REGISTER_EMAIL_CONFIRM            = false
     ENABLE_NOTIFY_MAIL                = false
-    DISABLE_REGISTRATION              = false
+    DISABLE_REGISTRATION              = true
     ENABLE_CAPTCHA                    = false
     REQUIRE_SIGNIN_VIEW               = false
     DEFAULT_KEEP_EMAIL_PRIVATE        = false


### PR DESCRIPTION
This PR disables the ability of external/anonymous users from creating new user accounts via UI. The proper way to handle user creation is with the `GiteaUser` CRD. Alternatively, it is also possible to create accounts with the [REST API](https://pkg.go.dev/code.gitea.io/sdk/gitea#Client.AdminCreateUser).